### PR TITLE
Add new social contact fields to validation rules

### DIFF
--- a/VALIDATION_RULES.md
+++ b/VALIDATION_RULES.md
@@ -49,6 +49,9 @@ The application implements comprehensive validation at both client and server le
 | `contact:github` | url | Valid URL format |
 | `contact:matrix` | url | Valid URL format |
 | `contact:geyser` | url | Valid URL format |
+| `contact:eventbrite` | url | Valid URL format |
+| `contact:reddit` | url | Valid URL format |
+| `contact:simplex` | url | Valid URL format |
 | `contact:rss` | url | Valid URL format |
 | `contact:meetup` | url | Valid URL format |
 | `contact:nostr` | text | Any non-empty string |

--- a/app.py
+++ b/app.py
@@ -137,6 +137,18 @@ AREA_TYPE_REQUIREMENTS = {
             'required': False,
             'type': 'url'
         },
+        'contact:eventbrite': {
+            'required': False,
+            'type': 'url'
+        },
+        'contact:reddit': {
+            'required': False,
+            'type': 'url'
+        },
+        'contact:simplex': {
+            'required': False,
+            'type': 'url'
+        },
         'tips:lightning_address': {
             'required': False,
             'type': 'text'


### PR DESCRIPTION
This PR adds three new social contact fields to the area validation rules:

- `contact:eventbrite` - Eventbrite profile URL
- `contact:reddit` - Reddit profile URL  
- `contact:simplex` - Simplex contact URL

All three fields are optional and validate as URLs, consistent with other social contact fields like Twitter, Discord, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new optional contact fields for community areas: Eventbrite, Reddit, and Simplex. Each field includes URL validation to ensure properly formatted links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->