### PR TITLE
Add contact:satlantis to validation rules

### DIFF
--- a/VALIDATION_RULES.md
+++ b/VALIDATION_RULES.md
@@ -52,6 +52,7 @@ The application implements comprehensive validation at both client and server le
 | `contact:eventbrite` | url | Valid URL format |
 | `contact:reddit` | url | Valid URL format |
 | `contact:simplex` | url | Valid URL format |
+| `contact:satlantis` | url | Valid URL format |
 | `contact:rss` | url | Valid URL format |
 | `contact:meetup` | url | Valid URL format |
 | `contact:nostr` | text | Any non-empty string |

--- a/app.py
+++ b/app.py
@@ -149,6 +149,10 @@ AREA_TYPE_REQUIREMENTS = {
             'required': False,
             'type': 'url'
         },
+        'contact:satlantis': {
+            'required': False,
+            'type': 'url'
+        },
         'tips:lightning_address': {
             'required': False,
             'type': 'text'


### PR DESCRIPTION
This PR adds a new social contact field to the area validation rules:

- `contact:satlantis` - Satlantis profile URL

This field is optional and validates as a URL, consistent with other social contact fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new optional contact field for Satlantis with URL validation to community area configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->