### PR TITLE
Fix type safety issues: handle API response type variations

### DIFF
--- a/app.py
+++ b/app.py
@@ -395,6 +395,9 @@ def show_area(area_id):
         if isinstance(tags, str):
             try:
                 tags = json.loads(tags)
+                if not isinstance(tags, dict):
+                    app.logger.error(f"Tags parsed to non-dict type in area {area_id}: {type(tags)}")
+                    tags = {}
             except json.JSONDecodeError:
                 app.logger.error(f"Invalid JSON string for tags in area {area_id}")
                 tags = {}

--- a/app.py
+++ b/app.py
@@ -391,10 +391,17 @@ def show_area(area_id):
         area['updated_at'] = format_date(area.get('updated_at'))
         area['last_sync'] = format_date(area.get('last_sync'))
 
-        area_type = area['tags'].get('type', '')
+        tags = area.get('tags', {})
+        if isinstance(tags, str):
+            try:
+                tags = json.loads(tags)
+            except json.JSONDecodeError:
+                app.logger.error(f"Invalid JSON string for tags in area {area_id}")
+                tags = {}
+        area_type = tags.get('type', '')
         type_requirements = AREA_TYPE_REQUIREMENTS.get(area_type, {})
 
-        geo_json = area['tags'].get('geo_json')
+        geo_json = tags.get('geo_json')
         if geo_json and isinstance(geo_json, str):
             try:
                 geo_json = json.loads(geo_json)
@@ -500,6 +507,9 @@ def add_area():
         if 'error' not in result:
             # Return the area ID so client can upload icon
             area_result = result.get('result', {})
+            if not isinstance(area_result, dict):
+                app.logger.warning(f"Unexpected result format from add_area RPC: {type(area_result)}")
+                return jsonify({'error': {'message': 'Invalid response from server'}}), 500
             area_id = area_result.get('id') or area_result.get('tags', {}).get('url_alias')
             return jsonify({'success': True, 'area_id': area_id})
         app.logger.error(f"Error from RPC call: {result['error']}")


### PR DESCRIPTION
This PR fixes potential runtime crashes caused by type confusion in API response handling.

## Changes

### 1. show_area function (lines 394-404)
**Issue:** 
The BTC Map API can return  as either a dict or a JSON string. The code assumed it was always a dict, which could cause  when calling  on a string.

**Fix:**
Added defensive type checking to handle both cases:
- Check if  is a string using 
- Parse JSON string to dict if needed
- Log error and default to empty dict on parse failure

### 2. add_area function (lines 507-512)
**Issue:**
The RPC result could be a non-dict type, causing  when accessing .

**Fix:**
- Validate that  is a dict before accessing it
- Log warning with the actual type received
- Return 500 error with descriptive message if invalid format

## Testing
- App imports successfully
- Changes are defensive - only activate when API returns unexpected types
- Existing functionality preserved for normal API responses

## Type Safety
These fixes address the LSP errors:
-  at lines 399, 402
-  at line 508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unexpected area tag data: now safely parses tag content, logs parse issues, and falls back to safe defaults to avoid display errors.
  * Hardened area-creation flow: responses from add-area operations are validated, returning a clear error when an invalid response is encountered to prevent downstream failures and ensure consistent error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->